### PR TITLE
Handle malformed tool selection responses

### DIFF
--- a/test/nameless-tool-calls.test.js
+++ b/test/nameless-tool-calls.test.js
@@ -1,0 +1,130 @@
+const path = require('path');
+
+const Helper = require('hubot-test-helper');
+// Mock Ollama to simulate nameless tool calls with configurable scripted responses
+jest.mock('ollama', () => {
+  let scriptedResponses = null;
+  let showResponse = { capabilities: ['tools', 'completion'] };
+
+  class MockOllama {
+    constructor() {
+      this._callCount = 0;
+    }
+    async show() {
+      return showResponse;
+    }
+    async chat() {
+      this._callCount += 1;
+      if (Array.isArray(scriptedResponses) && scriptedResponses[this._callCount - 1]) {
+        return scriptedResponses[this._callCount - 1];
+      }
+
+      // Default behavior used by the first test: nameless call with hint, then nameless again
+      if (this._callCount === 1) {
+        return {
+          message: {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_1',
+                function: { index: 0, name: '', arguments: { parameters: {}, type: 'hubot_ollama_get_current_time' } }
+              }
+            ]
+          }
+        };
+      }
+      if (this._callCount === 2) {
+        return {
+          message: {
+            role: 'assistant',
+            content: '',
+            tool_calls: [
+              {
+                id: 'call_2',
+                function: { index: 0, name: '', arguments: {} }
+              }
+            ]
+          }
+        };
+      }
+      // Should bail before reaching here; return empty to catch regressions
+      return { message: { role: 'assistant', content: '' } };
+    }
+  }
+
+  MockOllama.__setChatResponses = (responses) => {
+    scriptedResponses = responses;
+  };
+
+  MockOllama.__setShowResponse = (resp) => {
+    showResponse = resp;
+  };
+
+  return { Ollama: MockOllama };
+});
+
+const helper = new Helper(path.join(__dirname, '..', 'src', 'hubot-ollama.js'));
+
+describe('hubot-ollama nameless tool call bail-out', () => {
+  let room;
+
+  beforeEach(() => {
+    process.env.HUBOT_OLLAMA_TOOLS_ENABLED = 'true';
+    room = helper.createRoom();
+    // Mock logger to avoid console spam during tests
+    ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+      room.robot.logger[method] = jest.fn();
+    });
+  });
+
+  afterEach(() => {
+    room.destroy();
+    delete process.env.HUBOT_OLLAMA_TOOLS_ENABLED;
+    const MockOllama = require('ollama').Ollama;
+    if (MockOllama.__setChatResponses) {
+      MockOllama.__setChatResponses(null);
+    }
+  });
+
+  it('breaks out after repeated nameless tool calls', async () => {
+    await room.user.say('alice', 'hubot ask What tools do you have available?');
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const last = room.messages[room.messages.length - 1][1];
+    expect(last).toMatch(/recovered|answer|proceed|tool name|valid/i);
+  });
+
+  it('ignores nameless tool call with no hint and continues', async () => {
+    // Mock sequence: first response has nameless tool call with no arguments/hint; second responds normally
+    const responses = [
+      {
+        message: {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              function: { index: 0, name: '', arguments: {} }
+            }
+          ]
+        }
+      },
+      {
+        message: {
+          role: 'assistant',
+          content: 'No tools were used; here is a direct answer.'
+        }
+      }
+    ];
+
+    const MockOllama = require('ollama').Ollama;
+    MockOllama.__setChatResponses(responses);
+
+    await room.user.say('alice', 'hubot ask What tools do you have available?');
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const last = room.messages[room.messages.length - 1][1];
+    expect(last).toMatch(/No tools were used/i);
+  });
+});


### PR DESCRIPTION
This pull request improves the robustness of the `hubot-ollama` integration by handling repeated nameless or empty tool calls from the model, preventing infinite loops and providing clearer user feedback. It adds logic to recover from missing tool names when possible, bails out gracefully after repeated failures, and introduces comprehensive tests for these edge cases.

**Error handling and recovery for tool calls:**

* Implements detection and recovery for tool calls that are missing a name, using type hints when available, and logs detailed diagnostics for debugging. If recovery is not possible, the system retries without using tools or bails out with a clear message. [[1]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R485-R555) [[2]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9L577-R673) [[3]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R686-R704)
* Adds counters and thresholds to break out early after a configurable number of consecutive empty tool results or nameless tool calls, preventing infinite loops and informing the user when the system cannot proceed. [[1]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R453-R472) [[2]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R650-R654) [[3]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R748-R766) [[4]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R797-R816) [[5]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R828-R844) [[6]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R871-R876)

**Bug fixes and code safety:**

* Fixes cases where the code could access properties of undefined or malformed tool call objects by adding type and existence checks for tool names and function fields. [[1]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9L577-R673) [[2]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9L693-R857)

**Testing improvements:**

* Adds a new test file `nameless-tool-calls.test.js` to cover scenarios with repeated nameless tool calls, type hint recovery, and fallback behaviors, using a mocked Ollama client for deterministic testing.