### PR TITLE
feat: add addressed fallback response mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Prompts are sanitized and truncated if they exceed the configured limit.
 | `HUBOT_OLLAMA_CONTEXT_TTL_MS` | Optional | `600000` (10 min) | Time to maintain conversation history; `0` to disable |
 | `HUBOT_OLLAMA_CONTEXT_TURNS` | Optional | `5` | Maximum number of conversation turns to remember |
 | `HUBOT_OLLAMA_CONTEXT_SCOPE` | Optional | `room-user` | Context isolation: `room-user`, `room`, or `thread` |
+| `HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK` | Optional | `false` | Enable fallback replies for addressed messages when no other listener matched |
 | `HUBOT_OLLAMA_WEB_ENABLED` | Optional | `false` | Enable web-assisted workflow that can search/fetch context |
 | `HUBOT_OLLAMA_WEB_MAX_RESULTS` | Optional | `5` | Max search results to use (capped at 10) |
 | `HUBOT_OLLAMA_WEB_FETCH_CONCURRENCY` | Optional | `3` | Parallel fetch concurrency |
@@ -88,6 +89,20 @@ export HUBOT_OLLAMA_CONTEXT_TURNS=10
 export HUBOT_OLLAMA_CONTEXT_TTL_MS=1800000
 export HUBOT_OLLAMA_CONTEXT_SCOPE=room
 ```
+
+Enable addressed fallback mode:
+```bash
+export HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK=true
+```
+
+### Addressed Fallback Mode
+When `HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK=true`, hubot-ollama can answer without `ask`/`ollama`/`llm` prefixes, but only as a fallback.
+
+- It runs through Hubot `catchAll`, so it only triggers when no other listener matched first.
+- In shared rooms, fallback only triggers when explicitly addressed by bot name (for example: `hubot summarize this`).
+- Alias-only prefixes (for example: `! summarize this`) do **not** trigger fallback mode.
+- In direct messages/private chats, plain text is treated as addressed.
+- Explicit commands still work exactly as before (`hubot ask ...`, `hubot ollama ...`, `hubot llm ...`).
 
 ## Examples
 ```text

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ When `HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK=true`, hubot-ollama can answer 
 
 - It runs through Hubot `catchAll`, so it only triggers when no other listener matched first.
 - In shared rooms, fallback only triggers when explicitly addressed by bot name (for example: `hubot summarize this`).
-- Alias-only prefixes (for example: `! summarize this`) do **not** trigger fallback mode.
+- In shared rooms, alias-only prefixes (for example: `! summarize this`) do **not** trigger fallback mode.
 - In direct messages/private chats, plain text is treated as addressed.
 - Explicit commands still work exactly as before (`hubot ask ...`, `hubot ollama ...`, `hubot llm ...`).
 

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -17,6 +17,7 @@
 //   HUBOT_OLLAMA_WEB_FETCH_CONCURRENCY - Parallel fetch concurrency (default: 3)
 //   HUBOT_OLLAMA_WEB_MAX_BYTES - Max bytes of fetched content per page (default: 120000)
 //   HUBOT_OLLAMA_WEB_TIMEOUT_MS - Overall timeout for web phase (default: 45000)
+//   HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK - Enable fallback replies for addressed messages when no other listener matches (default: false)
 //
 // Commands:
 //   hubot ask <prompt> - Ask Ollama a question
@@ -59,6 +60,7 @@ module.exports = (robot) => {
   const WEB_FETCH_CONCURRENCY = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_FETCH_CONCURRENCY || '3', 10));
   const WEB_MAX_BYTES = Math.max(1024, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_MAX_BYTES || '120000', 10));
   const WEB_TIMEOUT_MS = Math.max(1000, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_TIMEOUT_MS || '45000', 10));
+  const RESPOND_TO_ADDRESSED_FALLBACK = /^1|true|yes$/i.test(process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK || '');
 
   // Emoji used with compatible adapters to indicate message is being processed
   const THINKING_EMOJI = 'hourglass_flowing_sand';
@@ -1049,6 +1051,32 @@ IMPORTANT: Keep the summary under 600 characters.`;
     }
   };
 
+  const escapeRegex = (value) => String(value).replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+
+  const isDirectMessage = (message) => {
+    if (!message || !message.user) return false;
+    const room = message.room || message.user.room;
+    const userName = message.user.name;
+    const userId = message.user.id;
+
+    if (!room || room === 'direct') return true;
+    if (userName && room === userName) return true;
+    if (userId && room === userId) return true;
+
+    return false;
+  };
+
+  // Fallback mode intentionally ignores alias-only prefixes (like '!') to avoid surprising captures.
+  const extractAddressedFallbackPrompt = (text) => {
+    if (typeof text !== 'string') return null;
+    const botName = (robot.name || '').trim();
+    if (!botName) return null;
+
+    const pattern = new RegExp(`^\\s*@?${escapeRegex(botName)}[:,]?\\s+(.+)\\s*$`, 'i');
+    const match = text.match(pattern);
+    return match ? match[1].trim() : null;
+  };
+
   // Shared handler for processing prompts from any source
   const handlePrompt = async (userPrompt, msg) => {
     if (!userPrompt || userPrompt.trim() === '') {
@@ -1100,4 +1128,21 @@ IMPORTANT: Keep the summary under 600 characters.`;
     robot.logger.debug(`User prompt: ${userPrompt}`);
     await handlePrompt(userPrompt, msg);
   });
+
+  if (RESPOND_TO_ADDRESSED_FALLBACK) {
+    robot.catchAll(async (msg) => {
+      const originalMessage = (msg && msg.message && (msg.message.message || msg.message)) || null;
+      const text = originalMessage && originalMessage.text;
+      if (typeof text !== 'string' || text.trim() === '') return;
+
+      const userPrompt = isDirectMessage(originalMessage)
+        ? text.trim()
+        : extractAddressedFallbackPrompt(text);
+
+      if (!userPrompt) return;
+
+      robot.logger.debug(`Fallback addressed prompt: ${userPrompt}`);
+      await handlePrompt(userPrompt, msg);
+    });
+  }
 };

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -1054,14 +1054,14 @@ IMPORTANT: Keep the summary under 600 characters.`;
   const escapeRegex = (value) => String(value).replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
   const isDirectMessage = (message) => {
-    if (!message || !message.user) return false;
-    const room = message.room || message.user.room;
-    const userName = message.user.name;
-    const userId = message.user.id;
+    if (!message) return false;
+    const room = message.room || (message.user && message.user.room);
+    const rawMessage = message.rawMessage || {};
 
-    if (!room || room === 'direct') return true;
-    if (userName && room === userName) return true;
-    if (userId && room === userId) return true;
+    // Prefer explicit adapter signals to avoid classifying Shell messages as DMs.
+    if (message.private === true) return true;
+    if (rawMessage.channel_type === 'im' || rawMessage.is_im === true) return true;
+    if (room === 'direct') return true;
 
     return false;
   };
@@ -1075,6 +1075,12 @@ IMPORTANT: Keep the summary under 600 characters.`;
     const pattern = new RegExp(`^\\s*@?${escapeRegex(botName)}[:,]?\\s+(.+)\\s*$`, 'i');
     const match = text.match(pattern);
     return match ? match[1].trim() : null;
+  };
+
+  const isCommandLikeFallbackPrompt = (prompt) => {
+    if (typeof prompt !== 'string') return false;
+    // Single-token prompts are often command misses (e.g., "Hubot deploy").
+    return /^[a-z0-9._-]+$/i.test(prompt.trim());
   };
 
   // Shared handler for processing prompts from any source
@@ -1135,11 +1141,13 @@ IMPORTANT: Keep the summary under 600 characters.`;
       const text = originalMessage && originalMessage.text;
       if (typeof text !== 'string' || text.trim() === '') return;
 
-      const userPrompt = isDirectMessage(originalMessage)
+      const isDirect = isDirectMessage(originalMessage);
+      const userPrompt = isDirect
         ? text.trim()
         : extractAddressedFallbackPrompt(text);
 
       if (!userPrompt) return;
+      if (!isDirect && isCommandLikeFallbackPrompt(userPrompt)) return;
 
       robot.logger.debug(`Fallback addressed prompt: ${userPrompt}`);
       await handlePrompt(userPrompt, msg);

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -60,7 +60,7 @@ module.exports = (robot) => {
   const WEB_FETCH_CONCURRENCY = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_FETCH_CONCURRENCY || '3', 10));
   const WEB_MAX_BYTES = Math.max(1024, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_MAX_BYTES || '120000', 10));
   const WEB_TIMEOUT_MS = Math.max(1000, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_TIMEOUT_MS || '45000', 10));
-  const RESPOND_TO_ADDRESSED_FALLBACK = /^1|true|yes$/i.test(process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK || '');
+  const RESPOND_TO_ADDRESSED_FALLBACK = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK || '');
 
   // Emoji used with compatible adapters to indicate message is being processed
   const THINKING_EMOJI = 'hourglass_flowing_sand';
@@ -1066,7 +1066,7 @@ IMPORTANT: Keep the summary under 600 characters.`;
     return false;
   };
 
-  // Fallback mode intentionally ignores alias-only prefixes (like '!') to avoid surprising captures.
+  // In shared rooms, fallback intentionally ignores alias-only prefixes (like '!') to avoid surprising captures.
   const extractAddressedFallbackPrompt = (text) => {
     if (typeof text !== 'string') return null;
     const botName = (robot.name || '').trim();

--- a/test/fixtures/fallback-claim-script.js
+++ b/test/fixtures/fallback-claim-script.js
@@ -1,0 +1,4 @@
+module.exports = (robot) => {
+  // This intentionally does not reply; it only marks the message as matched.
+  robot.respond(/.*/i, () => {});
+};

--- a/test/hubot-ollama.test.js
+++ b/test/hubot-ollama.test.js
@@ -3,6 +3,31 @@ const nock = require('nock');
 const Helper = require('./helpers/hubot-helper');
 
 const helper = new Helper('./../src/hubot-ollama.js');
+const fallbackClaimHelper = new Helper([
+  './fixtures/fallback-claim-script.js',
+  './../src/hubot-ollama.js'
+]);
+
+const createMockTextMessage = (text, {
+  userName = 'alice',
+  userId = 'U123',
+  room = 'room1'
+} = {}) => ({
+  text,
+  user: {
+    id: userId,
+    name: userName,
+    room
+  },
+  room,
+  done: false,
+  match(regex) {
+    return this.text.match(regex);
+  },
+  toString() {
+    return this.text;
+  }
+});
 
 describe('hubot-ollama', () => {
   let room = null;
@@ -31,6 +56,7 @@ describe('hubot-ollama', () => {
     delete process.env.HUBOT_OLLAMA_CONTEXT_TURNS;
     delete process.env.HUBOT_OLLAMA_HOST;
     delete process.env.HUBOT_OLLAMA_API_KEY;
+    delete process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK;
     delete process.env.HUBOT_OLLAMA_RESPOND_TO_DIRECT;
   });
 
@@ -131,6 +157,111 @@ describe('hubot-ollama', () => {
           ['hubot', 'Response using llm command'],
         ]);
       });
+    });
+  });
+
+  describe('Addressed Fallback Mode', () => {
+    it('is disabled by default', async () => {
+      room.user.say('alice', 'hubot tell me a joke');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', 'hubot tell me a joke'],
+      ]);
+      expect(nock.pendingMocks()).toEqual([]);
+    });
+
+    it('responds to explicit bot-name addressing when enabled', async () => {
+      room.destroy();
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      room = await helper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
+
+      mockOllamaChat('Fallback response from addressed mode');
+      room.user.say('alice', 'hubot explain memoization');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', 'hubot explain memoization'],
+        ['hubot', 'Fallback response from addressed mode'],
+      ]);
+    });
+
+    it('supports renamed bot names in addressed fallback mode', async () => {
+      room.destroy();
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      room = await helper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
+      room.robot.name = 'jarvis';
+
+      mockOllamaChat('Renamed bot fallback response');
+      room.user.say('alice', 'jarvis summarize this quickly');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', 'jarvis summarize this quickly'],
+        ['hubot', 'Renamed bot fallback response'],
+      ]);
+    });
+
+    it('does not trigger fallback on alias-like prefixes', async () => {
+      room.destroy();
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      room = await helper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
+
+      room.user.say('alice', '! explain memoization');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', '! explain memoization'],
+      ]);
+      expect(nock.pendingMocks()).toEqual([]);
+    });
+
+    it('treats direct-message plain text as addressed when enabled', async () => {
+      room.destroy();
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      room = await helper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
+
+      mockOllamaChat('DM fallback response');
+      room.user.say('alice', createMockTextMessage('give me a short recap', {
+        userName: 'alice',
+        userId: 'U111',
+        room: 'alice'
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', 'give me a short recap'],
+        ['hubot', 'DM fallback response'],
+      ]);
+    });
+
+    it('stays silent when another listener already matched', async () => {
+      room.destroy();
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      room = await fallbackClaimHelper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
+
+      room.user.say('alice', 'hubot explain cache invalidation');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', 'hubot explain cache invalidation'],
+      ]);
+      expect(nock.pendingMocks()).toEqual([]);
     });
   });
 

--- a/test/hubot-ollama.test.js
+++ b/test/hubot-ollama.test.js
@@ -11,7 +11,9 @@ const fallbackClaimHelper = new Helper([
 const createMockTextMessage = (text, {
   userName = 'alice',
   userId = 'U123',
-  room = 'room1'
+  room = 'room1',
+  privateMessage = false,
+  rawMessage = undefined
 } = {}) => ({
   text,
   user: {
@@ -20,6 +22,8 @@ const createMockTextMessage = (text, {
     room
   },
   room,
+  private: privateMessage,
+  rawMessage,
   done: false,
   match(regex) {
     return this.text.match(regex);
@@ -225,6 +229,23 @@ describe('hubot-ollama', () => {
       expect(nock.pendingMocks()).toEqual([]);
     });
 
+    it('does not trigger fallback on single-token command-like misses', async () => {
+      room.destroy();
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      room = await helper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
+
+      room.user.say('alice', 'hubot nomatch');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(room.messages).toEqual([
+        ['alice', 'hubot nomatch'],
+      ]);
+      expect(nock.pendingMocks()).toEqual([]);
+    });
+
     it('treats direct-message plain text as addressed when enabled', async () => {
       room.destroy();
       process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
@@ -237,7 +258,8 @@ describe('hubot-ollama', () => {
       room.user.say('alice', createMockTextMessage('give me a short recap', {
         userName: 'alice',
         userId: 'U111',
-        room: 'alice'
+        room: 'direct',
+        privateMessage: true
       }));
       await new Promise((resolve) => setTimeout(resolve, 150));
 


### PR DESCRIPTION
## Summary
- Add `HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK` as an opt-in mode for fallback responses.
- Register a `catchAll` fallback handler that only runs when no other listener matched.
- Route fallback prompts through existing `handlePrompt()` flow for consistent truncation, context, tooling, formatting, and errors.

## Behavior
- Shared rooms: fallback triggers only when explicitly addressed by bot name.
- Alias-only prefixes (for example `! ...`) do not trigger fallback.
- DMs/private chats: plain text is treated as addressed.
- Existing explicit commands (`ask`, `ollama`, `llm`) continue to work unchanged.

## Tests
- Add coverage for:
  - disabled-by-default behavior
  - enabled explicit-address fallback
  - renamed bot-name support
  - alias-like prefix exclusion
  - DM plain-text fallback
  - suppression when another listener already matched
- Add a test fixture script to claim messages without replying for collision validation.

## Docs
- Add configuration row and usage notes in README.
- Document caveat that fallback runs only when no other Hubot listener matched.
