### PR TITLE
Improve emoji reaction handling for Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ When `HUBOT_OLLAMA_WEB_ENABLED=true` and the connected Ollama host supports web 
 - Phase 3: The model incorporates the returned context into its final reply.
 - The bot sends a status message when the search is running and skips duplicate web searches in the same interaction.
 
+### Slack Reactions And Status
+When running with the Slack adapter, hubot-ollama uses reactions/status indicators on the triggering message:
+
+- `💭` (`thought_balloon`) while the main prompt is being processed.
+- `🛠️` (`hammer_and_wrench`) while a tool call is actively executing.
+- `⏳` status text is posted during web search (`_Searching web for relevant sources..._`).
+
+Reactions require Slack reaction scopes (for example, `reactions:write`).
+If reaction permissions are missing, the bot continues normally and keeps the existing web-search status message behavior.
+
 Enable:
 ```bash
 export HUBOT_OLLAMA_WEB_ENABLED=true

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -771,7 +771,12 @@ IMPORTANT: Keep the summary under 600 characters.`;
           robot.logger.debug(`Tool result: ${JSON.stringify(toolResults)}`);
           return { toolName, toolResults, wasNameless, unrecoverable: false };
         } finally {
-          if (toolReactionAdded) await removeThinkingReaction(msg, TOOL_INVOKED_EMOJI);
+          // Remove reaction asynchronously to avoid blocking critical path
+          if (toolReactionAdded) {
+            removeThinkingReaction(msg, TOOL_INVOKED_EMOJI).catch((err) => {
+              robot.logger.debug(`Tool reaction removal failed: ${err.message}`);
+            });
+          }
         }
       } catch (error) {
         robot.logger.error(`Tool execution failed: ${error.message}`);

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -63,8 +63,9 @@ module.exports = (robot) => {
   const WEB_TIMEOUT_MS = Math.max(1000, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_TIMEOUT_MS || '45000', 10));
   const RESPOND_TO_ADDRESSED_FALLBACK = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK || '');
 
-  // Emoji used with compatible adapters to indicate message is being processed
-  const THINKING_EMOJI = 'hourglass_flowing_sand';
+  // Emoji used with compatible adapters to indicate processing state
+  const REQUEST_THINKING_EMOJI = 'thought_balloon';
+  const TOOL_INVOKED_EMOJI = 'hammer_and_wrench';
 
   // For formatting instructions
   const adapterName = robot.adapterName ?? robot.adapter?.name;
@@ -760,12 +761,18 @@ IMPORTANT: Keep the summary under 600 characters.`;
         robot.logger.info(`Executing tool: ${toolName}`);
         if (toolCallLimits.hasOwnProperty(toolName)) toolCallCounts[toolName]++;
         if (!toolsUsed.includes(toolName)) toolsUsed.push(toolName);
-        const toolResults = await selectedTool.handler(
-          { ...toolArgs, _invocationContextKey: invocationContextKey },
-          robot, msg
-        );
-        robot.logger.debug(`Tool result: ${JSON.stringify(toolResults)}`);
-        return { toolName, toolResults, wasNameless, unrecoverable: false };
+        let toolReactionAdded = false;
+        try {
+          toolReactionAdded = await addThinkingReaction(msg, TOOL_INVOKED_EMOJI);
+          const toolResults = await selectedTool.handler(
+            { ...toolArgs, _invocationContextKey: invocationContextKey },
+            robot, msg
+          );
+          robot.logger.debug(`Tool result: ${JSON.stringify(toolResults)}`);
+          return { toolName, toolResults, wasNameless, unrecoverable: false };
+        } finally {
+          if (toolReactionAdded) await removeThinkingReaction(msg, TOOL_INVOKED_EMOJI);
+        }
       } catch (error) {
         robot.logger.error(`Tool execution failed: ${error.message}`);
         return { toolName, toolResults: { error: error.message }, wasNameless, unrecoverable: false };
@@ -1123,7 +1130,7 @@ IMPORTANT: Keep the summary under 600 characters.`;
     let reactionAdded = false;
     try {
       // Try to add a thinking reaction while processing (adapter-aware)
-      reactionAdded = await addThinkingReaction(msg, THINKING_EMOJI);
+      reactionAdded = await addThinkingReaction(msg, REQUEST_THINKING_EMOJI);
 
       const response = await askOllama(sanitizedPrompt, msg, conversationHistory, conversationSummary);
 
@@ -1144,7 +1151,7 @@ IMPORTANT: Keep the summary under 600 characters.`;
       msg.send(formatResponse(`Error: ${err.message || 'An unexpected error occurred while communicating with Ollama.'}`, msg));
     } finally {
       // Best-effort removal of the reaction once we're done
-      if (reactionAdded) await removeThinkingReaction(msg, THINKING_EMOJI);
+      if (reactionAdded) await removeThinkingReaction(msg, REQUEST_THINKING_EMOJI);
     }
   };
 

--- a/test/helpers/mock-message.js
+++ b/test/helpers/mock-message.js
@@ -1,0 +1,34 @@
+/**
+ * Helper to create mock Hubot text message objects for testing.
+ * Provides a consistent message shape across test suites.
+ */
+function createMockTextMessage(text, {
+  userName = 'alice',
+  userId = 'U123',
+  room = 'room1',
+  privateMessage = false,
+  rawMessage = undefined
+} = {}) {
+  return {
+    text,
+    user: {
+      id: userId,
+      name: userName,
+      room
+    },
+    room,
+    private: privateMessage,
+    rawMessage,
+    done: false,
+    match(regex) {
+      return this.text.match(regex);
+    },
+    toString() {
+      return this.text;
+    }
+  };
+}
+
+module.exports = {
+  createMockTextMessage
+};

--- a/test/hubot-ollama.test.js
+++ b/test/hubot-ollama.test.js
@@ -1,37 +1,13 @@
 const nock = require('nock');
 
 const Helper = require('./helpers/hubot-helper');
+const { createMockTextMessage } = require('./helpers/mock-message');
 
 const helper = new Helper('./../src/hubot-ollama.js');
 const fallbackClaimHelper = new Helper([
   './fixtures/fallback-claim-script.js',
   './../src/hubot-ollama.js'
 ]);
-
-const createMockTextMessage = (text, {
-  userName = 'alice',
-  userId = 'U123',
-  room = 'room1',
-  privateMessage = false,
-  rawMessage = undefined
-} = {}) => ({
-  text,
-  user: {
-    id: userId,
-    name: userName,
-    room
-  },
-  room,
-  private: privateMessage,
-  rawMessage,
-  done: false,
-  match(regex) {
-    return this.text.match(regex);
-  },
-  toString() {
-    return this.text;
-  }
-});
 
 describe('hubot-ollama', () => {
   let room = null;

--- a/test/hubot-ollama_slack.test.js
+++ b/test/hubot-ollama_slack.test.js
@@ -1,34 +1,12 @@
 const nock = require('nock');
 
 const Helper = require('./helpers/hubot-helper');
+const { createMockTextMessage } = require('./helpers/mock-message');
 
 const helper = new Helper([
   './adapters/slack.js',
   './../src/hubot-ollama.js'
 ]);
-
-const createMockTextMessage = (text, {
-  userName = 'alice',
-  userId = 'U123',
-  room = 'room1',
-  rawMessage = undefined
-} = {}) => ({
-  text,
-  user: {
-    id: userId,
-    name: userName,
-    room
-  },
-  room,
-  rawMessage,
-  done: false,
-  match(regex) {
-    return this.text.match(regex);
-  },
-  toString() {
-    return this.text;
-  }
-});
 
 describe('hubot-ollama slack', () => {
   let room = null;
@@ -56,6 +34,7 @@ describe('hubot-ollama slack', () => {
     delete process.env.HUBOT_OLLAMA_CONTEXT_TURNS;
     delete process.env.HUBOT_OLLAMA_HOST;
     delete process.env.HUBOT_OLLAMA_API_KEY;
+    delete process.env.HUBOT_OLLAMA_TOOLS_ENABLED;
   });  // Helper to create a mock Ollama API response
   const mockOllamaChat = (response, options = {}) => {
     const scope = nock(OLLAMA_HOST)
@@ -119,6 +98,11 @@ describe('hubot-ollama slack', () => {
   describe('Slack Reaction Lifecycle', () => {
     it('adds and removes thought balloon reaction around prompt handling', async () => {
       process.env.HUBOT_OLLAMA_TOOLS_ENABLED = 'false';
+      room.destroy();
+      room = await helper.createRoom();
+      ['debug', 'info', 'warning', 'error'].forEach((method) => {
+        room.robot.logger[method] = vi.fn();
+      });
 
       const addReaction = vi.fn().mockResolvedValue({ ok: true });
       const removeReaction = vi.fn().mockResolvedValue({ ok: true });
@@ -154,8 +138,6 @@ describe('hubot-ollama slack', () => {
         channel: 'room1',
         timestamp: '1716400000.000100'
       });
-
-      delete process.env.HUBOT_OLLAMA_TOOLS_ENABLED;
     });
 
   });

--- a/test/hubot-ollama_slack.test.js
+++ b/test/hubot-ollama_slack.test.js
@@ -7,6 +7,29 @@ const helper = new Helper([
   './../src/hubot-ollama.js'
 ]);
 
+const createMockTextMessage = (text, {
+  userName = 'alice',
+  userId = 'U123',
+  room = 'room1',
+  rawMessage = undefined
+} = {}) => ({
+  text,
+  user: {
+    id: userId,
+    name: userName,
+    room
+  },
+  room,
+  rawMessage,
+  done: false,
+  match(regex) {
+    return this.text.match(regex);
+  },
+  toString() {
+    return this.text;
+  }
+});
+
 describe('hubot-ollama slack', () => {
   let room = null;
   const OLLAMA_HOST = 'http://127.0.0.1:11434';
@@ -91,5 +114,49 @@ describe('hubot-ollama slack', () => {
         expect(room.robot.logger.debug).toHaveBeenCalledWith('Calling Ollama API with model: llama3.2');
       });
     });
+  });
+
+  describe('Slack Reaction Lifecycle', () => {
+    it('adds and removes thought balloon reaction around prompt handling', async () => {
+      process.env.HUBOT_OLLAMA_TOOLS_ENABLED = 'false';
+
+      const addReaction = vi.fn().mockResolvedValue({ ok: true });
+      const removeReaction = vi.fn().mockResolvedValue({ ok: true });
+      room.robot.adapter.client = {
+        web: {
+          reactions: {
+            add: addReaction,
+            remove: removeReaction
+          }
+        }
+      };
+
+      nock(OLLAMA_HOST)
+        .post('/api/show', { name: 'llama3.2' })
+        .reply(200, { capabilities: [] });
+
+      mockOllamaChat('Hello from Slack.');
+
+      await room.user.say('alice', createMockTextMessage('hubot ask hello', {
+        room: 'room1',
+        rawMessage: { ts: '1716400000.000100' }
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(addReaction).toHaveBeenCalledWith({
+        name: 'thought_balloon',
+        channel: 'room1',
+        timestamp: '1716400000.000100'
+      });
+
+      expect(removeReaction).toHaveBeenCalledWith({
+        name: 'thought_balloon',
+        channel: 'room1',
+        timestamp: '1716400000.000100'
+      });
+
+      delete process.env.HUBOT_OLLAMA_TOOLS_ENABLED;
+    });
+
   });
 });

--- a/test/hubot-ollama_web.test.js
+++ b/test/hubot-ollama_web.test.js
@@ -84,6 +84,33 @@ class MockOllama {
 mockRequire('ollama', { Ollama: MockOllama });
 
 const helper = new Helper(path.join(__dirname, '..', 'src', 'hubot-ollama.js'));
+const slackHelper = new Helper([
+  path.join(__dirname, 'adapters', 'slack.js'),
+  path.join(__dirname, '..', 'src', 'hubot-ollama.js')
+]);
+
+const createMockTextMessage = (text, {
+  userName = 'alice',
+  userId = 'U123',
+  room = 'room1',
+  rawMessage = undefined
+} = {}) => ({
+  text,
+  user: {
+    id: userId,
+    name: userName,
+    room
+  },
+  room,
+  rawMessage,
+  done: false,
+  match(regex) {
+    return this.text.match(regex);
+  },
+  toString() {
+    return this.text;
+  }
+});
 
 describe('hubot-ollama web-enabled flow', () => {
   let room;
@@ -134,5 +161,74 @@ describe('hubot-ollama web-enabled flow', () => {
     await new Promise((resolve) => setTimeout(resolve, 200));
     const last = room.messages[room.messages.length - 1][1];
     expect(last).toMatch(/Answer without web/);
+  });
+
+  it('keeps web-search status messaging when Slack reactions are not permitted', async () => {
+    room.destroy();
+    room = await slackHelper.createRoom();
+    ['debug', 'info', 'warning', 'error'].forEach((method) => {
+      room.robot.logger[method] = vi.fn();
+    });
+
+    room.robot.adapter.client = {
+      web: {
+        reactions: {
+          add: vi.fn().mockRejectedValue(new Error('missing_scope')),
+          remove: vi.fn().mockRejectedValue(new Error('missing_scope'))
+        }
+      }
+    };
+
+    await room.user.say('alice', createMockTextMessage('hubot ask summarize latest node release', {
+      room: 'room1',
+      rawMessage: { ts: '1716400000.000300' }
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const hasSearchStatus = room.messages.some((m) => {
+      const payload = m[1];
+      return m[0] === 'hubot' &&
+        typeof payload === 'object' &&
+        typeof payload.text === 'string' &&
+        /Searching web for relevant sources/.test(payload.text);
+    });
+
+    const last = room.messages[room.messages.length - 1][1];
+    const lastText = typeof last === 'string' ? last : last.text;
+    expect(hasSearchStatus).toBe(true);
+    expect(lastText).toMatch(/Answer with web context/);
+  });
+
+  it('adds and removes tool reaction during Slack web tool execution', async () => {
+    room.destroy();
+    room = await slackHelper.createRoom();
+    ['debug', 'info', 'warning', 'error'].forEach((method) => {
+      room.robot.logger[method] = vi.fn();
+    });
+
+    const addReaction = vi.fn().mockResolvedValue({ ok: true });
+    const removeReaction = vi.fn().mockResolvedValue({ ok: true });
+    room.robot.adapter.client = {
+      web: {
+        reactions: {
+          add: addReaction,
+          remove: removeReaction
+        }
+      }
+    };
+
+    await room.user.say('alice', createMockTextMessage('hubot ask summarize latest node release', {
+      room: 'room1',
+      rawMessage: { ts: '1716400000.000400' }
+    }));
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const addedNames = addReaction.mock.calls.map((call) => call[0].name);
+    const removedNames = removeReaction.mock.calls.map((call) => call[0].name);
+
+    expect(addedNames).toContain('thought_balloon');
+    expect(addedNames).toContain('hammer_and_wrench');
+    expect(removedNames).toContain('thought_balloon');
+    expect(removedNames).toContain('hammer_and_wrench');
   });
 });

--- a/test/hubot-ollama_web.test.js
+++ b/test/hubot-ollama_web.test.js
@@ -5,7 +5,7 @@ const mockRequire = require('mock-require');
 const registry = require('../src/tool-registry');
 
 const Helper = require('./helpers/hubot-helper');
-
+const { createMockTextMessage } = require('./helpers/mock-message');
 
 class MockOllama {
   constructor() {}
@@ -88,29 +88,6 @@ const slackHelper = new Helper([
   path.join(__dirname, 'adapters', 'slack.js'),
   path.join(__dirname, '..', 'src', 'hubot-ollama.js')
 ]);
-
-const createMockTextMessage = (text, {
-  userName = 'alice',
-  userId = 'U123',
-  room = 'room1',
-  rawMessage = undefined
-} = {}) => ({
-  text,
-  user: {
-    id: userId,
-    name: userName,
-    room
-  },
-  room,
-  rawMessage,
-  done: false,
-  match(regex) {
-    return this.text.match(regex);
-  },
-  toString() {
-    return this.text;
-  }
-});
 
 describe('hubot-ollama web-enabled flow', () => {
   let room;


### PR DESCRIPTION
This pull request enhances Slack integration for `hubot-ollama` by adding support for Slack reactions (emojis) to indicate bot status during prompt processing and tool execution. It also introduces robust lifecycle management for these reactions and ensures fallback to status messages if Slack reaction permissions are missing. Comprehensive tests are added to verify the new behavior.

**Slack Reaction Integration:**

* Added support for using Slack reactions: `thought_balloon` while processing prompts and `hammer_and_wrench` during tool execution, including automatic cleanup/removal of these reactions after processing. (`src/hubot-ollama.js`, `README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R122-R131) [[2]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9L66-R68) [[3]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9R764-R775) [[4]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9L1126-R1133) [[5]](diffhunk://#diff-cdb09b3359f2093423e5455dc3572dbf457f4ad7386f7c282b477f4d3763f9b9L1147-R1154)
* If Slack reaction permissions are missing, the bot gracefully falls back to the existing web-search status message behavior. (`src/hubot-ollama.js`, `README.md`)

**Testing Improvements:**

* Added new tests to verify correct addition and removal of reactions during prompt handling and tool execution, and to ensure fallback messaging works when reactions are not permitted. (`test/hubot-ollama_slack.test.js`, `test/hubot-ollama_web.test.js`) [[1]](diffhunk://#diff-075eba1a580b572b28c3b0664e277c02f31d34fa58f60cac239fc64de3e9e0a4R10-R32) [[2]](diffhunk://#diff-075eba1a580b572b28c3b0664e277c02f31d34fa58f60cac239fc64de3e9e0a4R118-R161) [[3]](diffhunk://#diff-6cc94056cdd8fb0864a5e17a5e50c3e63de266f095541403083ac20a82b21d47R87-R113) [[4]](diffhunk://#diff-6cc94056cdd8fb0864a5e17a5e50c3e63de266f095541403083ac20a82b21d47R165-R233)
* Introduced a `createMockTextMessage` helper for more flexible test message creation. (`test/hubot-ollama_slack.test.js`, `test/hubot-ollama_web.test.js`) [[1]](diffhunk://#diff-075eba1a580b572b28c3b0664e277c02f31d34fa58f60cac239fc64de3e9e0a4R10-R32) [[2]](diffhunk://#diff-6cc94056cdd8fb0864a5e17a5e50c3e63de266f095541403083ac20a82b21d47R87-R113)

These changes improve user experience on Slack by providing clear, real-time feedback on bot activity and ensure reliability even when Slack permissions are limited.