### PR TITLE
Optionally add ambient conversation to context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
-test-results/*
+test-results

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Prompts are sanitized and truncated if they exceed the configured limit.
 | `HUBOT_OLLAMA_CONTEXT_TURNS` | Optional | `5` | Maximum number of conversation turns to remember |
 | `HUBOT_OLLAMA_CONTEXT_SCOPE` | Optional | `room-user` | Context isolation: `room-user`, `room`, or `thread` |
 | `HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK` | Optional | `false` | Enable fallback replies for addressed messages when no other listener matched |
+| `HUBOT_OLLAMA_AMBIENT_CONTEXT` | Optional | `false` | Passively capture recent room messages as background context for answers |
+| `HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE` | Optional | `10` | Number of recent ambient messages to retain per room |
 | `HUBOT_OLLAMA_WEB_ENABLED` | Optional | `false` | Enable web-assisted workflow that can search/fetch context |
 | `HUBOT_OLLAMA_WEB_MAX_RESULTS` | Optional | `5` | Max search results to use (capped at 10) |
 | `HUBOT_OLLAMA_WEB_FETCH_CONCURRENCY` | Optional | `3` | Parallel fetch concurrency |
@@ -95,6 +97,12 @@ Enable addressed fallback mode:
 export HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK=true
 ```
 
+Enable ambient context:
+```bash
+export HUBOT_OLLAMA_AMBIENT_CONTEXT=true
+export HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE=15  # optional, default 10
+```
+
 ### Addressed Fallback Mode
 When `HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK=true`, hubot-ollama can answer without `ask`/`ollama`/`llm` prefixes, but only as a fallback.
 
@@ -111,6 +119,22 @@ hubot ask explain vector embeddings
 hubot llm generate a short motivational quote
 hubot ollama compare sql vs nosql
 ```
+
+### Ambient Context
+When `HUBOT_OLLAMA_AMBIENT_CONTEXT=true`, the bot passively listens to recent room conversation and uses it as background context when answering questions — without users needing to repeat themselves.
+
+```text
+Bob>   We have that conference in Tampa next week.
+Alice> Hopefully we'll get some good sales leads.
+Bob>   Yep, should be great.
+Bob>   hubot ask What should I pack for the trip?
+Hubot> Weather in Tampa next week looks to be sunny and warm. I'd skip the heavy suit.
+```
+
+- Opt-in only (`HUBOT_OLLAMA_AMBIENT_CONTEXT=false` by default)
+- Only captures undirected room messages — messages addressed to the bot are excluded
+- Stores the last `HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE` messages per room in a ring buffer (not persisted across restarts)
+- Direct messages are never captured
 
 ### Web-Enabled Workflow
 When `HUBOT_OLLAMA_WEB_ENABLED=true` and the connected Ollama host supports web tools, the bot registers `hubot_ollama_web_search` and the LLM can invoke it directly. The flow now is:

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -18,6 +18,8 @@
 //   HUBOT_OLLAMA_WEB_MAX_BYTES - Max bytes of fetched content per page (default: 120000)
 //   HUBOT_OLLAMA_WEB_TIMEOUT_MS - Overall timeout for web phase (default: 45000)
 //   HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK - Enable fallback replies for addressed messages when no other listener matches (default: false)
+//   HUBOT_OLLAMA_AMBIENT_CONTEXT - Passively capture recent room messages as background context for answers (default: false)
+//   HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE - Number of recent ambient messages to retain per room (default: 10)
 //
 // Commands:
 //   hubot ask <prompt> - Ask Ollama a question
@@ -28,6 +30,7 @@
 /** @typedef {import('ollama').ToolCall} OllamaToolCall */
 /** @typedef {import('ollama').ChatResponse} OllamaChatResponse */
 
+const { CatchAllMessage } = require('hubot');
 const { Ollama } = require('ollama');
 
 const registry = require('./tool-registry');
@@ -62,6 +65,8 @@ module.exports = (robot) => {
   const WEB_MAX_BYTES = Math.max(1024, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_MAX_BYTES || '120000', 10));
   const WEB_TIMEOUT_MS = Math.max(1000, Number.parseInt(process.env.HUBOT_OLLAMA_WEB_TIMEOUT_MS || '45000', 10));
   const RESPOND_TO_ADDRESSED_FALLBACK = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK || '');
+  const AMBIENT_CONTEXT = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT || '');
+  const AMBIENT_CONTEXT_SIZE = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE || '10', 10));
 
   // Emoji used with compatible adapters to indicate processing state
   const REQUEST_THINKING_EMOJI = 'thought_balloon';
@@ -69,6 +74,19 @@ module.exports = (robot) => {
 
   // For formatting instructions
   const adapterName = robot.adapterName ?? robot.adapter?.name;
+
+  // In-memory ring buffer of recent undirected room messages, keyed by room ID.
+  // Not persisted — ambient context is intentionally ephemeral.
+  const ambientBuffer = new Map();
+
+  const pushAmbient = (roomId, userName, text) => {
+    if (!ambientBuffer.has(roomId)) ambientBuffer.set(roomId, []);
+    const buf = ambientBuffer.get(roomId);
+    buf.push({ userName, text });
+    if (buf.length > AMBIENT_CONTEXT_SIZE) buf.shift();
+  };
+
+  const getAmbientMessages = (roomId) => ambientBuffer.get(roomId) || [];
 
   // Build the complete default system prompt
   const getDefaultInstructionPrompt = () => {
@@ -608,6 +626,17 @@ IMPORTANT: Keep the summary under 600 characters.`;
         }
         messages.push({ role: 'user', content: userContent });
         messages.push({ role: 'assistant', content: turn.assistant });
+      }
+    }
+
+    // Inject recent ambient room messages as background context
+    if (AMBIENT_CONTEXT) {
+      const roomId = msg && msg.message && (msg.message.room || (msg.message.user && msg.message.user.room));
+      const ambient = roomId ? getAmbientMessages(roomId) : [];
+      if (ambient.length > 0) {
+        const formatted = ambient.map(m => `${m.userName}: ${m.text}`).join('\n');
+        messages.push({ role: 'system', content: `Recent room conversation:\n${formatted}` });
+        robot.logger.debug(`Injected ${ambient.length} ambient messages from room ${roomId}`);
       }
     }
 
@@ -1175,6 +1204,25 @@ IMPORTANT: Keep the summary under 600 characters.`;
       if (reactionAdded) await removeThinkingReaction(msg, REQUEST_THINKING_EMOJI);
     }
   };
+
+  // Passively capture undirected room messages for ambient context.
+  // Uses receiveMiddleware rather than robot.hear() so that catchAll listeners
+  // (e.g. RESPOND_TO_ADDRESSED_FALLBACK) are not blocked — a matching hear()
+  // listener prevents catchAll from firing in Hubot v14.
+  if (AMBIENT_CONTEXT) {
+    robot.receiveMiddleware(async (context) => {
+      const message = context.response && context.response.message;
+      if (!message || message instanceof CatchAllMessage) return;
+      if (isDirectMessage(message)) return;
+      const text = (message.text || '').trim();
+      if (!text) return;
+      if (extractAddressedFallbackPrompt(text)) return;
+      const roomId = message.room || (message.user && message.user.room);
+      if (!roomId) return;
+      const userName = (message.user && (message.user.real_name || message.user.name)) || 'Unknown';
+      pushAmbient(roomId, userName, text);
+    });
+  }
 
   // Main command handler
   robot.respond(/(?:ask|ollama|llm):?\s+(.+)/i, async (msg) => {

--- a/test/ambient-context.test.js
+++ b/test/ambient-context.test.js
@@ -1,0 +1,221 @@
+const nock = require('nock');
+
+const Helper = require('./helpers/hubot-helper');
+
+const helper = new Helper('./../src/hubot-ollama.js');
+
+describe('Ambient Context', () => {
+  let room;
+  const OLLAMA_HOST = 'http://127.0.0.1:11434';
+
+  beforeEach(async () => {
+    process.env.HUBOT_OLLAMA_MODEL = 'llama3.2';
+    process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT = 'true';
+    room = await helper.createRoom();
+    ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+      room.robot.logger[method] = vi.fn();
+    });
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    room.destroy();
+    nock.cleanAll();
+    delete process.env.HUBOT_OLLAMA_MODEL;
+    delete process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT;
+    delete process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE;
+  });
+
+  const mockOllamaChat = (response, captureBody = null) =>
+    nock(OLLAMA_HOST)
+      .post('/api/chat', (body) => { if (captureBody) captureBody.value = body; return true; })
+      .reply(200, { message: { role: 'assistant', content: response }, done: true });
+
+  it('is disabled by default', async () => {
+    room.destroy();
+    delete process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT;
+    room = await helper.createRoom();
+    ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+      room.robot.logger[method] = vi.fn();
+    });
+
+    const body = {};
+    mockOllamaChat('response', body);
+
+    await room.user.say('alice', 'The conference is in Tampa next week.');
+    await room.user.say('bob', 'hubot ask what should I pack?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeUndefined();
+  });
+
+  it('captures undirected room messages and injects them as context', async () => {
+    const body = {};
+    mockOllamaChat('Pack light clothes.', body);
+
+    await room.user.say('alice', 'The conference is in Tampa next week.');
+    await room.user.say('alice', 'Hopefully we get some good leads.');
+    await room.user.say('bob', 'hubot ask what should I pack?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeDefined();
+    expect(ambientMsg.content).toContain('The conference is in Tampa next week.');
+    expect(ambientMsg.content).toContain('Hopefully we get some good leads.');
+  });
+
+  it('does not capture bot-addressed messages', async () => {
+    const body = {};
+    mockOllamaChat('response', body);
+
+    // Only bot-directed message — nothing undirected
+    await room.user.say('bob', 'hubot ask what should I pack?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeUndefined();
+  });
+
+  it('does not inject ambient context when buffer is empty', async () => {
+    const body = {};
+    mockOllamaChat('response', body);
+
+    await room.user.say('bob', 'hubot ask what time is it?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeUndefined();
+  });
+
+  it('respects AMBIENT_CONTEXT_SIZE as a ring buffer', async () => {
+    room.destroy();
+    process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE = '2';
+    room = await helper.createRoom();
+    ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+      room.robot.logger[method] = vi.fn();
+    });
+
+    const body = {};
+    mockOllamaChat('response', body);
+
+    await room.user.say('alice', 'message one');
+    await room.user.say('alice', 'message two');
+    await room.user.say('alice', 'message three');
+    await room.user.say('bob', 'hubot ask what did alice say last?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeDefined();
+    expect(ambientMsg.content).not.toContain('message one');
+    expect(ambientMsg.content).toContain('message two');
+    expect(ambientMsg.content).toContain('message three');
+  });
+
+  it('includes the sender name in ambient context', async () => {
+    const body = {};
+    mockOllamaChat('response', body);
+
+    await room.user.say('alice', 'We ship on Friday.');
+    await room.user.say('bob', 'hubot ask when do we ship?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeDefined();
+    expect(ambientMsg.content).toContain('alice: We ship on Friday.');
+  });
+
+  describe('with RESPOND_TO_ADDRESSED_FALLBACK enabled', () => {
+    let fallbackRoom;
+
+    beforeEach(async () => {
+      process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK = 'true';
+      fallbackRoom = await helper.createRoom();
+      ['debug', 'info', 'warn', 'warning', 'error'].forEach((method) => {
+        fallbackRoom.robot.logger[method] = vi.fn();
+      });
+    });
+
+    afterEach(() => {
+      fallbackRoom.destroy();
+      delete process.env.HUBOT_OLLAMA_RESPOND_TO_ADDRESSED_FALLBACK;
+    });
+
+    it('does not capture fallback-addressed messages in the ambient buffer', async () => {
+      const body = {};
+      mockOllamaChat('Sure, here is a joke.', body);
+
+      // This is bot-addressed (fallback) — should NOT enter the ambient buffer
+      await fallbackRoom.user.say('alice', 'hubot tell me a joke');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const ambientMsg = body.value?.messages?.find(
+        (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+      );
+      expect(ambientMsg).toBeUndefined();
+    });
+
+    it('includes undirected messages in context when fallback mode answers', async () => {
+      const body = {};
+      // Two undirected messages first, then a fallback-addressed question
+      await fallbackRoom.user.say('alice', 'The conference is in Tampa next week.');
+      await fallbackRoom.user.say('bob', 'Hopefully we get some good leads.');
+
+      mockOllamaChat('Pack light — Tampa is warm.', body);
+      await fallbackRoom.user.say('bob', 'hubot what should I pack?');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const ambientMsg = body.value?.messages?.find(
+        (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+      );
+      expect(ambientMsg).toBeDefined();
+      expect(ambientMsg.content).toContain('The conference is in Tampa next week.');
+      expect(ambientMsg.content).toContain('Hopefully we get some good leads.');
+      // The fallback-addressed message itself must not appear in ambient context
+      expect(ambientMsg.content).not.toContain('what should I pack');
+    });
+
+    it('fallback still responds correctly when ambient context is enabled', async () => {
+      mockOllamaChat('Fallback works fine.');
+      await fallbackRoom.user.say('alice', 'hubot explain memoization');
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(fallbackRoom.messages).toEqual([
+        ['alice', 'hubot explain memoization'],
+        ['hubot', 'Fallback works fine.'],
+      ]);
+    });
+  });
+
+  it('does not capture direct messages', async () => {
+    const body = {};
+    mockOllamaChat('response', body);
+
+    const { createMockTextMessage } = require('./helpers/mock-message');
+    const dmMessage = createMockTextMessage('secret plans', {
+      userName: 'alice',
+      privateMessage: true
+    });
+    await room.receive('alice', dmMessage);
+
+    await room.user.say('bob', 'hubot ask what are the plans?');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const ambientMsg = body.value?.messages?.find(
+      (m) => m.role === 'system' && m.content?.startsWith('Recent room conversation')
+    );
+    expect(ambientMsg).toBeUndefined();
+  });
+});


### PR DESCRIPTION
When `HUBOT_OLLAMA_AMBIENT_CONTEXT` is enabled, allows Hubot to use recent messages not directly addressed to the bot in the overall context window. Allows the bot to participate in general conversation.
