### PR TITLE
Add hubot_ollama_memory tool for persistent, scoped caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,11 @@ See orchestration flow in [src/hubot-ollama.js](src/hubot-ollama.js) and baselin
 - Conditionally registered (when web + tools gates are met):
   - `hubot_ollama_web_search`
   - `hubot_ollama_web_fetch`
+- Conditionally registered (when `HUBOT_OLLAMA_TOOLS_ENABLED=true` and `HUBOT_OLLAMA_MEMORY_ENABLED=true`, on by default):
+  - `hubot_ollama_memory` — save/recall/list/delete persistent facts in `robot.brain`, scoped by `getContextKey()` (same scoping as conversation context)
 
 Where these are registered: [src/hubot-ollama.js](src/hubot-ollama.js).
-Where they are implemented: [src/tools/javascript-repl-tool.js](src/tools/javascript-repl-tool.js), [src/tools/web-search-tool.js](src/tools/web-search-tool.js), [src/tools/web-fetch-tool.js](src/tools/web-fetch-tool.js).
+Where they are implemented: [src/tools/javascript-repl-tool.js](src/tools/javascript-repl-tool.js), [src/tools/web-search-tool.js](src/tools/web-search-tool.js), [src/tools/web-fetch-tool.js](src/tools/web-fetch-tool.js), [src/tools/memory-tool.js](src/tools/memory-tool.js).
 
 ### Registration Contract
 Tools are registered through [src/tool-registry.js](src/tool-registry.js) using:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Prompts are sanitized and truncated if they exceed the configured limit.
 | `HUBOT_OLLAMA_AMBIENT_CONTEXT` | Optional | `false` | Passively capture recent room messages as background context for answers |
 | `HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE` | Optional | `10` | Number of recent ambient messages to retain per room |
 | `HUBOT_OLLAMA_COMMAND_TOOL_ENABLED` | Optional | `false` | Allow the LLM to invoke other Hubot commands on the user's behalf and read the response |
+| `HUBOT_OLLAMA_MEMORY_ENABLED` | Optional | `true` | Allow the LLM to save/recall persistent memories via `robot.brain` |
+| `HUBOT_OLLAMA_MEMORY_MAX_ENTRIES` | Optional | `200` | Max memory entries per context scope before least-recently-accessed eviction |
+| `HUBOT_OLLAMA_MEMORY_MAX_CONTENT_CHARS` | Optional | `4000` | Max characters stored per memory entry |
+| `HUBOT_OLLAMA_MEMORY_MAX_SUMMARY_CHARS` | Optional | `200` | Max characters for a memory's summary |
 | `HUBOT_OLLAMA_WEB_ENABLED` | Optional | `false` | Enable web-assisted workflow that can search/fetch context |
 | `HUBOT_OLLAMA_WEB_MAX_RESULTS` | Optional | `5` | Max search results to use (capped at 10) |
 | `HUBOT_OLLAMA_WEB_FETCH_CONCURRENCY` | Optional | `3` | Parallel fetch concurrency |
@@ -207,6 +211,29 @@ gives up and reports no response.
 
 ```bash
 export HUBOT_OLLAMA_COMMAND_TOOL_ENABLED=true
+```
+
+**Persistent Memory (on by default):**
+The bot registers `hubot_ollama_memory`, a caching aid the model can use to avoid re-deriving, re-fetching, or
+re-asking for the same information across conversations — e.g. a fact the user already gave it, or a slow tool
+result worth reusing instead of recomputing. This is meant to make the bot more efficient, not to give users a
+"remember this about me" command; the model decides on its own when caching something is worthwhile. The tool
+supports four actions: `save`, `recall`, `list`, and `delete`. `list` returns only keys and summaries (cheap to
+browse); `recall` returns the full content for a specific key. Memories are scoped using the same context key
+as conversation history (see [Context Scopes](#conversation-context)), so privacy follows whatever
+`HUBOT_OLLAMA_CONTEXT_SCOPE` is already configured — a `room-user` scope keeps memories private per user,
+`room` shares them with everyone in the room. The model is instructed to only save information it's confident
+is accurate (something explicitly stated or an already-verified tool result, never a guess), and saves that
+look like passwords, API keys, tokens, or other credentials are rejected by a best-effort regex guardrail — it
+catches common, recognizably-shaped pastes but is not a security boundary; don't rely on it to catch every
+credential format. Each context scope holds at most `HUBOT_OLLAMA_MEMORY_MAX_ENTRIES` entries; past that, the
+least-recently-accessed entry is evicted to make room for a new one.
+
+```bash
+export HUBOT_OLLAMA_MEMORY_ENABLED=false        # opt out (default: true)
+export HUBOT_OLLAMA_MEMORY_MAX_ENTRIES=200
+export HUBOT_OLLAMA_MEMORY_MAX_CONTENT_CHARS=4000
+export HUBOT_OLLAMA_MEMORY_MAX_SUMMARY_CHARS=200
 ```
 
 **Example Tool Interaction:**

--- a/src/hubot-ollama.js
+++ b/src/hubot-ollama.js
@@ -21,6 +21,10 @@
 //   HUBOT_OLLAMA_AMBIENT_CONTEXT - Passively capture recent room messages as background context for answers (default: false)
 //   HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE - Number of recent ambient messages to retain per room (default: 10)
 //   HUBOT_OLLAMA_COMMAND_TOOL_ENABLED - Allow the LLM to invoke other Hubot commands on the user's behalf (default: false)
+//   HUBOT_OLLAMA_MEMORY_ENABLED - Allow the LLM to save/recall persistent memories via robot.brain (default: true)
+//   HUBOT_OLLAMA_MEMORY_MAX_ENTRIES - Max memory entries per context scope before least-recently-accessed eviction (default: 200)
+//   HUBOT_OLLAMA_MEMORY_MAX_CONTENT_CHARS - Max characters stored per memory entry (default: 4000)
+//   HUBOT_OLLAMA_MEMORY_MAX_SUMMARY_CHARS - Max characters for a memory's summary (default: 200)
 //
 // Commands:
 //   hubot ask <prompt> - Ask Ollama a question
@@ -37,6 +41,7 @@ const registry = require('./tool-registry');
 const createHubotCommandTool = require('./tools/hubot-command-tool');
 const createHubotHelpTool = require('./tools/hubot-help-tool');
 const createJavaScriptReplTool = require('./tools/javascript-repl-tool');
+const createMemoryTool = require('./tools/memory-tool');
 const createWebFetchTool = require('./tools/web-fetch-tool');
 const createWebSearchTool = require('./tools/web-search-tool');
 const { applyLoggerShims } = require('./utils/hubot-compat');
@@ -69,6 +74,10 @@ module.exports = (robot) => {
   const AMBIENT_CONTEXT = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT || '');
   const AMBIENT_CONTEXT_SIZE = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_AMBIENT_CONTEXT_SIZE || '10', 10));
   const COMMAND_TOOL_ENABLED = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_COMMAND_TOOL_ENABLED || '');
+  const MEMORY_ENABLED = /^(?:1|true|yes)$/i.test(process.env.HUBOT_OLLAMA_MEMORY_ENABLED || 'true');
+  const MEMORY_MAX_ENTRIES = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_MEMORY_MAX_ENTRIES || '200', 10));
+  const MEMORY_MAX_CONTENT_CHARS = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_MEMORY_MAX_CONTENT_CHARS || '4000', 10));
+  const MEMORY_MAX_SUMMARY_CHARS = Math.max(1, Number.parseInt(process.env.HUBOT_OLLAMA_MEMORY_MAX_SUMMARY_CHARS || '200', 10));
 
   // Emoji used with compatible adapters to indicate processing state
   const REQUEST_THINKING_EMOJI = 'thought_balloon';
@@ -400,6 +409,25 @@ IMPORTANT: Keep the summary under 600 characters.`;
     robot.logger.debug(`Conversation context key=${key} scope=${CONTEXT_SCOPE}`);
     return key;
   };
+
+  // Register memory tool unless explicitly disabled (on by default, opt-out
+  // via HUBOT_OLLAMA_MEMORY_ENABLED=false). Registered here (rather than
+  // alongside the other tools above) because it depends on getContextKey,
+  // which is defined just above.
+  if (TOOLS_ENABLED && MEMORY_ENABLED) {
+    const memoryTool = createMemoryTool(null, {
+      MAX_ENTRIES: MEMORY_MAX_ENTRIES,
+      MAX_CONTENT_CHARS: MEMORY_MAX_CONTENT_CHARS,
+      MAX_SUMMARY_CHARS: MEMORY_MAX_SUMMARY_CHARS,
+      getContextKey
+    }, robot.logger);
+    registry.registerTool(memoryTool.name, {
+      description: memoryTool.description,
+      parameters: memoryTool.parameters,
+      handler: memoryTool.handler
+    });
+    robot.logger.debug('Registered memory tool');
+  }
 
   // Get conversation history for a user, cleaning up expired contexts
   // Returns { history: [], summary: null }

--- a/src/tools/memory-tool.js
+++ b/src/tools/memory-tool.js
@@ -35,7 +35,7 @@ module.exports = (ollama, config, logger) => ({
     },
     summary: {
       type: 'string',
-      description: 'Short description of the memory (required for save)'
+      description: 'Short description of the memory (optional for save; defaults to a truncated copy of content when omitted)'
     },
     content: {
       type: 'string',
@@ -131,7 +131,7 @@ module.exports = (ollama, config, logger) => ({
       const rawSummaryTrimmed = typeof rawSummary === 'string' ? rawSummary.trim() : '';
       const summarySource = rawSummaryTrimmed || cappedContent;
       const summary = summarySource.length > maxSummaryChars
-        ? `${summarySource.slice(0, maxSummaryChars)}...`
+        ? `${summarySource.slice(0, Math.max(0, maxSummaryChars - 3))}...`
         : summarySource;
 
       const now = Date.now();

--- a/src/tools/memory-tool.js
+++ b/src/tools/memory-tool.js
@@ -1,0 +1,168 @@
+// Persistent memory tool for Ollama integration
+// Lets the model save/recall/list/delete short facts in robot.brain, scoped by
+// the same context key used for conversation history (see getContextKey in
+// hubot-ollama.js), so memory privacy follows HUBOT_OLLAMA_CONTEXT_SCOPE.
+
+const { looksLikeSecret } = require('../utils/ollama-utils');
+
+const BRAIN_KEY = 'ollamaMemory';
+const VALID_ACTIONS = new Set(['save', 'recall', 'list', 'delete']);
+const MAX_KEY_CHARS = 100;
+
+module.exports = (ollama, config, logger) => ({
+  name: 'hubot_ollama_memory',
+  description:
+    'Cache information across conversations so you avoid re-deriving, re-fetching, or ' +
+    're-asking for it next time — e.g. a fact the user already gave you, a slow or expensive ' +
+    "result from another tool, or a detail you'd otherwise have to look up again. " +
+    "Actions: 'save' (store it under a short key with a summary and full content), " +
+    "'recall' (get full content for a key), 'list' (browse keys and summaries only, no " +
+    "content — cheap to check before saving or recalling), 'delete' (remove a stale or " +
+    'incorrect key). Guidelines: only save information you are confident is accurate — ' +
+    'something the user explicitly stated or a tool result you already verified — never a ' +
+    "guess or inference. Before saving, consider calling 'list' first — if an existing key " +
+    'already covers this, reuse that key (save overwrites) instead of creating a ' +
+    'near-duplicate entry. Never save secrets: passwords, API keys, tokens, or credentials ' +
+    '— these will be rejected.',
+  parameters: {
+    action: {
+      type: 'string',
+      description: 'One of: save, recall, list, delete'
+    },
+    key: {
+      type: 'string',
+      description: 'Short identifier for this memory (required for save/recall/delete)'
+    },
+    summary: {
+      type: 'string',
+      description: 'Short description of the memory (required for save)'
+    },
+    content: {
+      type: 'string',
+      description: 'Full content to store (required for save)'
+    }
+  },
+  handler: async (args, robot, msg) => {
+    const { action, key: rawKey, summary: rawSummary, content: rawContent } = args || {};
+
+    try {
+      if (!VALID_ACTIONS.has(action)) {
+        return { error: `Invalid action "${action}". Must be one of: save, recall, list, delete` };
+      }
+
+      // Refuse to operate on a message we can't attribute to a specific room/user.
+      // Without this, a malformed msg (missing message.room or message.user) collapses
+      // to getContextKey's shared fallback bucket, letting unrelated callers read/write
+      // the same persistent memory — a much bigger deal here than for TTL'd conversation
+      // context, since these entries don't expire on their own.
+      const messageInfo = msg && msg.message;
+      const hasResolvableRoom = Boolean(messageInfo && messageInfo.room);
+      const hasResolvableUser = Boolean(messageInfo && messageInfo.user && (messageInfo.user.id || messageInfo.user.name));
+      if (!hasResolvableRoom || !hasResolvableUser) {
+        logger?.warn('Memory tool refusing to operate: message has no resolvable room/user, would collide with the shared fallback context key');
+        return { error: 'Unable to resolve a specific conversation context for this message; memory actions are unavailable here.' };
+      }
+
+      const getContextKey = config && config.getContextKey;
+      if (typeof getContextKey !== 'function') {
+        logger?.error('Memory tool misconfigured: no getContextKey provided');
+        return { error: 'Memory tool is not properly configured' };
+      }
+      const scopeKey = getContextKey(msg);
+
+      if (!robot.brain.get(BRAIN_KEY)) {
+        robot.brain.set(BRAIN_KEY, {});
+      }
+      const memory = robot.brain.get(BRAIN_KEY);
+      if (!memory[scopeKey]) {
+        memory[scopeKey] = {};
+      }
+      const scope = memory[scopeKey];
+
+      const maxEntries = (config && config.MAX_ENTRIES) || 200;
+      const maxContentChars = (config && config.MAX_CONTENT_CHARS) || 4000;
+      const maxSummaryChars = (config && config.MAX_SUMMARY_CHARS) || 200;
+
+      if (action === 'list') {
+        const entries = Object.entries(scope)
+          .map(([key, entry]) => ({ key, summary: entry.summary, updatedAt: entry.updatedAt }))
+          .sort((a, b) => b.updatedAt - a.updatedAt);
+        return { entries };
+      }
+
+      const key = typeof rawKey === 'string' ? rawKey.trim().slice(0, MAX_KEY_CHARS) : '';
+      if (!key) {
+        return { error: 'A "key" is required for this action' };
+      }
+
+      if (action === 'recall') {
+        const entry = scope[key];
+        if (!entry) {
+          return { error: `No memory found for key "${key}"` };
+        }
+        entry.lastAccessedAt = Date.now();
+        robot.brain.set(BRAIN_KEY, memory);
+        return { key, summary: entry.summary, content: entry.content, updatedAt: entry.updatedAt };
+      }
+
+      if (action === 'delete') {
+        if (!scope[key]) {
+          return { error: `No memory found for key "${key}"` };
+        }
+        delete scope[key];
+        robot.brain.set(BRAIN_KEY, memory);
+        return { deleted: true, key };
+      }
+
+      // action === 'save'
+      const content = typeof rawContent === 'string' ? rawContent.trim() : '';
+      if (!content) {
+        return { error: 'Content is required to save a memory' };
+      }
+
+      if (looksLikeSecret(content) || looksLikeSecret(rawSummary)) {
+        logger?.warn('Memory tool rejected save: content looks like a secret or credential');
+        return { error: 'Refusing to store content that looks like a secret or credential' };
+      }
+
+      const truncated = content.length > maxContentChars;
+      const cappedContent = truncated ? content.slice(0, maxContentChars) : content;
+
+      const rawSummaryTrimmed = typeof rawSummary === 'string' ? rawSummary.trim() : '';
+      const summarySource = rawSummaryTrimmed || cappedContent;
+      const summary = summarySource.length > maxSummaryChars
+        ? `${summarySource.slice(0, maxSummaryChars)}...`
+        : summarySource;
+
+      const now = Date.now();
+      const existing = scope[key];
+
+      if (!existing && Object.keys(scope).length >= maxEntries) {
+        const [lruKey] = Object.entries(scope)
+          .sort((a, b) => a[1].lastAccessedAt - b[1].lastAccessedAt)[0];
+        logger?.debug(`Memory tool evicting least-recently-accessed key "${lruKey}" (scope at capacity)`);
+        delete scope[lruKey];
+      }
+
+      scope[key] = {
+        summary,
+        content: cappedContent,
+        createdAt: existing ? existing.createdAt : now,
+        updatedAt: now,
+        lastAccessedAt: now
+      };
+      robot.brain.set(BRAIN_KEY, memory);
+
+      return {
+        saved: true,
+        key,
+        summaryChars: summary.length,
+        contentChars: cappedContent.length,
+        truncated
+      };
+    } catch (error) {
+      logger?.error(`Memory tool error: ${error.message}`);
+      return { error: error.message };
+    }
+  }
+});

--- a/src/utils/ollama-utils.js
+++ b/src/utils/ollama-utils.js
@@ -69,6 +69,35 @@ function detectPromptInjection(text) {
 }
 
 /**
+ * Common secret/credential shapes, plus a generic labeled-field heuristic
+ * (`key: value` / `key=value` where key looks like a credential field).
+ * Heuristic only, not a security boundary — intended to catch obvious
+ * accidental pastes before they're persisted to long-term storage.
+ */
+const SECRET_PATTERNS = [
+  /AKIA[A-Z0-9]{16}/, // AWS access key ID
+  /sk-[A-Za-z0-9]{20,}/, // OpenAI-style secret key
+  /ghp_[A-Za-z0-9]{36}/, // GitHub personal access token
+  /xox[baprs]-[A-Za-z0-9-]+/i, // Slack token
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/, // PEM private key
+  // Labeled field, e.g. `password: x`, `API_KEY=x`, `"apiToken":"x"` — allows
+  // arbitrary word-char prefixes/suffixes and surrounding quotes so snake_case
+  // (AUTH_TOKEN=), camelCase (apiToken), and JSON-quoted keys are all caught.
+  /["']?[\w.-]*(password|passwd|api[_-]?key|secret|token|credential)[\w-]*["']?\s*[:=]\s*["']?\S+/i,
+];
+
+/**
+ * Detect content that looks like a secret or credential.
+ * Heuristic only; callers should reject storage rather than silently strip.
+ * @param {string} text
+ * @returns {boolean}
+ */
+function looksLikeSecret(text) {
+  if (!text || typeof text !== 'string') return false;
+  return SECRET_PATTERNS.some(pattern => pattern.test(text));
+}
+
+/**
  * Return the thread_ts of an existing thread the message belongs to, or null.
  * Does NOT fall back to the message's own ts — use this when you need to know
  * whether the message is already inside a thread (e.g. context key scoping).
@@ -118,6 +147,7 @@ module.exports = {
   sanitizeText,
   sanitizeSlackBroadcasts,
   detectPromptInjection,
+  looksLikeSecret,
   truncate,
   getAdapterType,
   getExistingSlackThread,

--- a/test/memory-tool.test.js
+++ b/test/memory-tool.test.js
@@ -98,17 +98,38 @@ describe('memory-tool', () => {
   });
 
   test('list returns summaries only, sorted by updatedAt desc, no content', async () => {
+    vi.useFakeTimers();
+    try {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+
+      vi.setSystemTime(1000);
+      await tool.handler({ action: 'save', key: 'first', summary: 'First', content: 'a' }, robot, msg);
+      vi.setSystemTime(2000);
+      await tool.handler({ action: 'save', key: 'second', summary: 'Second', content: 'b' }, robot, msg);
+
+      const listResult = await tool.handler({ action: 'list' }, robot, msg);
+      expect(listResult.entries).toHaveLength(2);
+      expect(listResult.entries[0].key).toBe('second');
+      expect(listResult.entries[0]).not.toHaveProperty('content');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('truncated summary never exceeds MAX_SUMMARY_CHARS (including the ellipsis)', async () => {
     const robot = makeRobot();
-    const tool = memoryTool(null, makeConfig(), logger);
+    const tool = memoryTool(null, makeConfig({ MAX_SUMMARY_CHARS: 10 }), logger);
 
-    await tool.handler({ action: 'save', key: 'first', summary: 'First', content: 'a' }, robot, msg);
-    await new Promise((resolve) => setTimeout(resolve, 2));
-    await tool.handler({ action: 'save', key: 'second', summary: 'Second', content: 'b' }, robot, msg);
+    const result = await tool.handler(
+      { action: 'save', key: 'k', summary: 'a'.repeat(20), content: 'content' },
+      robot, msg
+    );
+    expect(result.summaryChars).toBeLessThanOrEqual(10);
 
-    const listResult = await tool.handler({ action: 'list' }, robot, msg);
-    expect(listResult.entries).toHaveLength(2);
-    expect(listResult.entries[0].key).toBe('second');
-    expect(listResult.entries[0]).not.toHaveProperty('content');
+    const recallResult = await tool.handler({ action: 'recall', key: 'k' }, robot, msg);
+    expect(recallResult.summary.length).toBeLessThanOrEqual(10);
+    expect(recallResult.summary).toBe('aaaaaaa...');
   });
 
   test('truncates content longer than MAX_CONTENT_CHARS', async () => {
@@ -183,24 +204,30 @@ describe('memory-tool', () => {
   });
 
   test('evicts least-recently-accessed entry when scope is at capacity', async () => {
-    const robot = makeRobot();
-    const tool = memoryTool(null, makeConfig({ MAX_ENTRIES: 2 }), logger);
+    vi.useFakeTimers();
+    try {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig({ MAX_ENTRIES: 2 }), logger);
 
-    await tool.handler({ action: 'save', key: 'a', content: 'A' }, robot, msg);
-    await new Promise((resolve) => setTimeout(resolve, 2));
-    await tool.handler({ action: 'save', key: 'b', content: 'B' }, robot, msg);
+      vi.setSystemTime(1000);
+      await tool.handler({ action: 'save', key: 'a', content: 'A' }, robot, msg);
+      vi.setSystemTime(2000);
+      await tool.handler({ action: 'save', key: 'b', content: 'B' }, robot, msg);
 
-    // Refresh "a"'s lastAccessedAt so "b" becomes the least-recently-accessed entry
-    await new Promise((resolve) => setTimeout(resolve, 2));
-    await tool.handler({ action: 'recall', key: 'a' }, robot, msg);
+      // Refresh "a"'s lastAccessedAt so "b" becomes the least-recently-accessed entry
+      vi.setSystemTime(3000);
+      await tool.handler({ action: 'recall', key: 'a' }, robot, msg);
 
-    // Saving a new entry should evict "b", not "a"
-    await new Promise((resolve) => setTimeout(resolve, 2));
-    await tool.handler({ action: 'save', key: 'c', content: 'C' }, robot, msg);
+      // Saving a new entry should evict "b", not "a"
+      vi.setSystemTime(4000);
+      await tool.handler({ action: 'save', key: 'c', content: 'C' }, robot, msg);
 
-    const listResult = await tool.handler({ action: 'list' }, robot, msg);
-    const keys = listResult.entries.map((e) => e.key).sort();
-    expect(keys).toEqual(['a', 'c']);
+      const listResult = await tool.handler({ action: 'list' }, robot, msg);
+      const keys = listResult.entries.map((e) => e.key).sort();
+      expect(keys).toEqual(['a', 'c']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   describe('unresolvable context refusal', () => {

--- a/test/memory-tool.test.js
+++ b/test/memory-tool.test.js
@@ -1,0 +1,269 @@
+const memoryTool = require('../src/tools/memory-tool');
+
+describe('memory-tool', () => {
+  const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn() };
+
+  const makeRobot = () => {
+    const store = {};
+    return {
+      brain: {
+        get: vi.fn((key) => store[key]),
+        set: vi.fn((key, value) => { store[key] = value; })
+      }
+    };
+  };
+
+  const makeConfig = (overrides = {}) => ({
+    getContextKey: () => 'room1:user1',
+    ...overrides
+  });
+
+  const msg = { message: { room: 'room1', user: { id: 'user1' } } };
+
+  test('tool definition includes required properties', () => {
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    expect(tool.name).toBe('hubot_ollama_memory');
+    expect(tool.description).toBeTruthy();
+    expect(typeof tool.handler).toBe('function');
+    expect(tool.parameters.action).toBeTruthy();
+  });
+
+  test('save then recall round-trip', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const saveResult = await tool.handler(
+      { action: 'save', key: 'fav-color', summary: 'Favorite color', content: 'Teal' },
+      robot, msg
+    );
+    expect(saveResult).toEqual({ saved: true, key: 'fav-color', summaryChars: 14, contentChars: 4, truncated: false });
+
+    const recallResult = await tool.handler({ action: 'recall', key: 'fav-color' }, robot, msg);
+    expect(recallResult).toMatchObject({ key: 'fav-color', summary: 'Favorite color', content: 'Teal' });
+  });
+
+  test('save defaults summary to content when omitted', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    await tool.handler({ action: 'save', key: 'note', content: 'Some note content' }, robot, msg);
+    const recallResult = await tool.handler({ action: 'recall', key: 'note' }, robot, msg);
+
+    expect(recallResult.summary).toBe('Some note content');
+  });
+
+  test('save requires key', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler({ action: 'save', content: 'content' }, robot, msg);
+    expect(result).toHaveProperty('error');
+  });
+
+  test('save requires content', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler({ action: 'save', key: 'k' }, robot, msg);
+    expect(result.error).toContain('Content is required');
+  });
+
+  test('recall on missing key returns error', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler({ action: 'recall', key: 'nope' }, robot, msg);
+    expect(result.error).toContain('No memory found');
+  });
+
+  test('delete on missing key returns error', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler({ action: 'delete', key: 'nope' }, robot, msg);
+    expect(result.error).toContain('No memory found');
+  });
+
+  test('delete removes an existing key', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    await tool.handler({ action: 'save', key: 'k', content: 'v' }, robot, msg);
+    const deleteResult = await tool.handler({ action: 'delete', key: 'k' }, robot, msg);
+    expect(deleteResult).toEqual({ deleted: true, key: 'k' });
+
+    const recallResult = await tool.handler({ action: 'recall', key: 'k' }, robot, msg);
+    expect(recallResult).toHaveProperty('error');
+  });
+
+  test('list returns summaries only, sorted by updatedAt desc, no content', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    await tool.handler({ action: 'save', key: 'first', summary: 'First', content: 'a' }, robot, msg);
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await tool.handler({ action: 'save', key: 'second', summary: 'Second', content: 'b' }, robot, msg);
+
+    const listResult = await tool.handler({ action: 'list' }, robot, msg);
+    expect(listResult.entries).toHaveLength(2);
+    expect(listResult.entries[0].key).toBe('second');
+    expect(listResult.entries[0]).not.toHaveProperty('content');
+  });
+
+  test('truncates content longer than MAX_CONTENT_CHARS', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig({ MAX_CONTENT_CHARS: 10 }), logger);
+
+    const result = await tool.handler({ action: 'save', key: 'k', content: 'a'.repeat(20) }, robot, msg);
+    expect(result.truncated).toBe(true);
+    expect(result.contentChars).toBe(10);
+
+    const recallResult = await tool.handler({ action: 'recall', key: 'k' }, robot, msg);
+    expect(recallResult.content).toBe('a'.repeat(10));
+  });
+
+  test('invalid action returns error', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler({ action: 'destroy' }, robot, msg);
+    expect(result.error).toContain('Invalid action');
+  });
+
+  test('rejects content that looks like a secret', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler(
+      { action: 'save', key: 'k', content: 'password: hunter2' },
+      robot, msg
+    );
+    expect(result.error).toContain('secret or credential');
+
+    const listResult = await tool.handler({ action: 'list' }, robot, msg);
+    expect(listResult.entries).toHaveLength(0);
+  });
+
+  test('rejects an API-key-shaped token', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler(
+      { action: 'save', key: 'k', content: `Use token sk-${'a'.repeat(30)}` },
+      robot, msg
+    );
+    expect(result.error).toContain('secret or credential');
+  });
+
+  test('does not false-positive on ordinary prose mentioning "password"', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig(), logger);
+
+    const result = await tool.handler(
+      { action: 'save', key: 'k', content: 'The user forgot their password and needs a reset link.' },
+      robot, msg
+    );
+    expect(result).toHaveProperty('saved', true);
+  });
+
+  test('scope isolation: entries in one context are not visible in another', async () => {
+    const robot = makeRobot();
+    let currentScope = 'room1:user1';
+    const tool = memoryTool(null, makeConfig({ getContextKey: () => currentScope }), logger);
+
+    await tool.handler({ action: 'save', key: 'k', content: 'scope1 value' }, robot, msg);
+
+    currentScope = 'room2:user2';
+    const listResult = await tool.handler({ action: 'list' }, robot, msg);
+    expect(listResult.entries).toHaveLength(0);
+
+    const recallResult = await tool.handler({ action: 'recall', key: 'k' }, robot, msg);
+    expect(recallResult).toHaveProperty('error');
+  });
+
+  test('evicts least-recently-accessed entry when scope is at capacity', async () => {
+    const robot = makeRobot();
+    const tool = memoryTool(null, makeConfig({ MAX_ENTRIES: 2 }), logger);
+
+    await tool.handler({ action: 'save', key: 'a', content: 'A' }, robot, msg);
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await tool.handler({ action: 'save', key: 'b', content: 'B' }, robot, msg);
+
+    // Refresh "a"'s lastAccessedAt so "b" becomes the least-recently-accessed entry
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await tool.handler({ action: 'recall', key: 'a' }, robot, msg);
+
+    // Saving a new entry should evict "b", not "a"
+    await new Promise((resolve) => setTimeout(resolve, 2));
+    await tool.handler({ action: 'save', key: 'c', content: 'C' }, robot, msg);
+
+    const listResult = await tool.handler({ action: 'list' }, robot, msg);
+    const keys = listResult.entries.map((e) => e.key).sort();
+    expect(keys).toEqual(['a', 'c']);
+  });
+
+  describe('unresolvable context refusal', () => {
+    test('refuses when msg has no room', async () => {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+      const badMsg = { message: { user: { id: 'user1' } } };
+
+      const result = await tool.handler({ action: 'save', key: 'k', content: 'v' }, robot, badMsg);
+      expect(result.error).toContain('Unable to resolve');
+      expect(robot.brain.set).not.toHaveBeenCalled();
+    });
+
+    test('refuses when msg has no user', async () => {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+      const badMsg = { message: { room: 'room1' } };
+
+      const result = await tool.handler({ action: 'list' }, robot, badMsg);
+      expect(result.error).toContain('Unable to resolve');
+    });
+
+    test('refuses when msg is missing entirely', async () => {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+
+      const result = await tool.handler({ action: 'list' }, robot, {});
+      expect(result.error).toContain('Unable to resolve');
+    });
+  });
+
+  describe('broadened secret guardrail', () => {
+    test('rejects a snake_case labeled token (e.g. AUTH_TOKEN=...)', async () => {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+
+      const result = await tool.handler(
+        { action: 'save', key: 'k', content: 'AUTH_TOKEN=abc123xyz' },
+        robot, msg
+      );
+      expect(result.error).toContain('secret or credential');
+    });
+
+    test('rejects a *_KEY labeled field (e.g. SECRET_KEY=...)', async () => {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+
+      const result = await tool.handler(
+        { action: 'save', key: 'k', content: 'SECRET_KEY=abc123xyz' },
+        robot, msg
+      );
+      expect(result.error).toContain('secret or credential');
+    });
+
+    test('rejects a JSON-quoted credential field', async () => {
+      const robot = makeRobot();
+      const tool = memoryTool(null, makeConfig(), logger);
+
+      const result = await tool.handler(
+        { action: 'save', key: 'k', content: '{"apiToken":"xyz123abc456"}' },
+        robot, msg
+      );
+      expect(result.error).toContain('secret or credential');
+    });
+  });
+});

--- a/test/ollama-utils.test.js
+++ b/test/ollama-utils.test.js
@@ -160,4 +160,45 @@ describe('ollama-utils', () => {
       expect(utils.detectPromptInjection('IGNORE PREVIOUS INSTRUCTIONS')).toBe(true);
     });
   });
+
+  describe('looksLikeSecret', () => {
+    test('detects an AWS access key ID', () => {
+      expect(utils.looksLikeSecret('key is AKIAIOSFODNN7EXAMPLE')).toBe(true);
+    });
+    test('detects an OpenAI-style secret key', () => {
+      expect(utils.looksLikeSecret(`sk-${'a'.repeat(30)}`)).toBe(true);
+    });
+    test('detects a GitHub personal access token', () => {
+      expect(utils.looksLikeSecret(`ghp_${'a'.repeat(36)}`)).toBe(true);
+    });
+    test('detects a Slack token', () => {
+      expect(utils.looksLikeSecret('xoxb-1234567890-abcdefg')).toBe(true);
+    });
+    test('detects a PEM private key header', () => {
+      expect(utils.looksLikeSecret('-----BEGIN RSA PRIVATE KEY-----')).toBe(true);
+    });
+    test('detects a labeled credential field', () => {
+      expect(utils.looksLikeSecret('api_key: abc123')).toBe(true);
+      expect(utils.looksLikeSecret('password=hunter2')).toBe(true);
+    });
+    test('detects a snake_case labeled field (e.g. AUTH_TOKEN=...)', () => {
+      expect(utils.looksLikeSecret('AUTH_TOKEN=abc123xyz')).toBe(true);
+    });
+    test('detects a *_KEY labeled field (e.g. SECRET_KEY=...)', () => {
+      expect(utils.looksLikeSecret('SECRET_KEY=abc123xyz')).toBe(true);
+    });
+    test('detects a JSON-quoted credential field', () => {
+      expect(utils.looksLikeSecret('{"apiToken":"xyz123abc456"}')).toBe(true);
+    });
+    test('does not flag ordinary prose mentioning "password"', () => {
+      expect(utils.looksLikeSecret('The user forgot their password and needs a reset link.')).toBe(false);
+    });
+    test('does not flag normal text', () => {
+      expect(utils.looksLikeSecret('The weather today is sunny with a high of 75.')).toBe(false);
+    });
+    test('does not flag empty or null input', () => {
+      expect(utils.looksLikeSecret('')).toBe(false);
+      expect(utils.looksLikeSecret(null)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `hubot_ollama_memory`, an LLM-callable tool (`save`/`recall`/`list`/`delete`) that lets the model cache short facts in `robot.brain` across conversations, avoiding re-deriving/re-fetching/re-asking for the same information — framed as an efficiency aid for the model, not a user-facing "remember this" feature.
- Memory is scoped using the existing `getContextKey(msg)` helper already used for conversation history, so privacy automatically follows whatever `HUBOT_OLLAMA_CONTEXT_SCOPE` is configured (`room-user`/`room`/`thread`) — no new isolation config needed.
- Bounded growth: per-entry char caps (`HUBOT_OLLAMA_MEMORY_MAX_CONTENT_CHARS`/`MAX_SUMMARY_CHARS`) plus a max-entry-count cap per scope (`HUBOT_OLLAMA_MEMORY_MAX_ENTRIES`, default 200), evicting the least-recently-*accessed* (not oldest-created) entry once at capacity.
- Guardrails: a regex check (`looksLikeSecret()`) rejects saves that look like passwords/API keys/tokens/credentials (best-effort, not a security boundary — documented as such); the tool refuses to operate when a message has no resolvable room/user, rather than silently collapsing into a shared fallback context key.
- On by default (`HUBOT_OLLAMA_MEMORY_ENABLED`, opt-out).

## Test plan
- [x] `npm run lint`
- [x] `npm test` (337 tests passing, including new coverage for save/recall/list/delete round-trips, LRU eviction ordering, scope isolation, secret-guardrail true/false positives, and the unresolvable-context refusal)
- [ ] Manual check against a running Ollama instance with a tool-capable model: enable `HUBOT_OLLAMA_TOOLS_ENABLED=true`, exercise `hubot ask` prompts that plausibly trigger save/recall across two separate interactions in the same room/user scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)